### PR TITLE
Fix number lookup API URI

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -43,7 +43,7 @@ final class ApiClient implements ApiClientInterface
         }
 
         try {
-            $response = $this->client->request('GET', \sprintf('/entities/%s', $businessNumber))->getContent();
+            $response = $this->client->request('GET', \sprintf('entities/%s', $businessNumber))->getContent();
         } catch (HttpExceptionInterface | TransportExceptionInterface $e) {
             if (404 === $e->getCode()) {
                 throw new NumberNotFoundException();

--- a/src/Model/AddressDenormalizer.php
+++ b/src/Model/AddressDenormalizer.php
@@ -18,7 +18,7 @@ final class AddressDenormalizer implements DenormalizerInterface, DenormalizerAw
     /**
      * @param mixed $data
      *
-     * @psalm-assert-if-true array{addressList:array, links:array|array} $data
+     * @psalm-assert-if-true array{addressList:array, links:array} $data
      */
     public function supportsDenormalization($data, string $type, string $format = null): bool
     {

--- a/src/Stubs/StubHttpClient.php
+++ b/src/Stubs/StubHttpClient.php
@@ -34,7 +34,7 @@ final class StubHttpClient implements HttpClientInterface
 
         return match (true) {
             (bool) \preg_match('/^entities\/(9429\\d{9})+$/i', $url) => $this->handleCompanyRequest($url, $options),
-            default                                                    => throw new \LogicException(
+            default                                                  => throw new \LogicException(
                 'Not implemented: NZ Companies Office API client only responds to "/entities/{companyNumber}"'
             )
         };

--- a/src/Stubs/StubHttpClient.php
+++ b/src/Stubs/StubHttpClient.php
@@ -33,7 +33,7 @@ final class StubHttpClient implements HttpClientInterface
         }
 
         return match (true) {
-            (bool) \preg_match('/^\/entities\/(9429\\d{9})+$/i', $url) => $this->handleCompanyRequest($url, $options),
+            (bool) \preg_match('/^entities\/(9429\\d{9})+$/i', $url) => $this->handleCompanyRequest($url, $options),
             default                                                    => throw new \LogicException(
                 'Not implemented: NZ Companies Office API client only responds to "/entities/{companyNumber}"'
             )

--- a/tests/Integration/ApiClientTest.php
+++ b/tests/Integration/ApiClientTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ApiClientTest extends TestCase
 {
-    private const BusinessNumber = '9429033128887';
+    private const BusinessNumber = '9429041264959';
 
     private Generator $faker;
 


### PR DESCRIPTION
URI had an extra slash at the start causing the URL to be invalid