### PR TITLE
Fix business number validator to take company prefix into account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,10 @@ phpunit:
 .PHONY: phpunit-github
 phpunit-github:
 	php vendor/bin/phpunit --printer mheap\\GithubActionsReporter\\Printer
+
+.PHONY: all
+all:
+	make fix
+	make psalm
+	make phpstan
+	make phpunit

--- a/src/BusinessNumberValidator.php
+++ b/src/BusinessNumberValidator.php
@@ -8,11 +8,18 @@ use Pmigut\GtinValidator\Gtin13;
 
 final class BusinessNumberValidator
 {
+    public const COMPANY_PREFIX = '9429';
+
     public static function isValidNumber(string $businessNumber): bool
     {
         // Replace whitespace and hyphens
         $businessNumber = \preg_replace('/[\s-]+/', '', $businessNumber);
         if (null === $businessNumber) {
+            return false;
+        }
+
+        // Ensure number starts with the NZBN company prefix
+        if (false === \str_starts_with($businessNumber, self::COMPANY_PREFIX)) {
             return false;
         }
 

--- a/src/Stubs/BusinessNumberFaker.php
+++ b/src/Stubs/BusinessNumberFaker.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace Hyra\NzCompaniesOfficeLookup\Stubs;
 
+use Hyra\NzCompaniesOfficeLookup\BusinessNumberValidator;
+
 final class BusinessNumberFaker
 {
-    private function __construct()
-    {
-    }
-
     public static function validBusinessNumber(): string
     {
         // NZBN company prefix
-        $companyPrefix = '9429';
+        $companyPrefix = BusinessNumberValidator::COMPANY_PREFIX;
 
         // @phpstan-ignore-next-line it can find an appropriate source of randomness
-        $randomNumber = \str_pad((string) \random_int(0, 9999999), 8, '0', \STR_PAD_LEFT);
+        $randomNumber = \str_pad((string) \random_int(0, 99_999_999), 8, '0', \STR_PAD_LEFT);
 
         $checkDigit = 0;
         for ($i = 0; $i < 12; $i += 2) {
@@ -31,6 +29,8 @@ final class BusinessNumberFaker
     public static function invalidBusinessNumber(): string
     {
         // @phpstan-ignore-next-line it can find an appropriate source of randomness
-        return \str_pad((string) \random_int(0, 9999999), 13, '0', \STR_PAD_LEFT);
+        $randomNumber = \str_pad((string) \random_int(0, 999_999_999), 9, '0', \STR_PAD_LEFT);
+
+        return \sprintf('1234%s', $randomNumber);
     }
 }

--- a/tests/Integration/ApiClientTest.php
+++ b/tests/Integration/ApiClientTest.php
@@ -116,8 +116,7 @@ final class ApiClientTest extends TestCase
             'entityTypeDescription' => $response->entityTypeDescription,
             'status'                => $response->status,
             'registrationDate'      => $response->registrationDate->format('Y-m-d\TH:i:s.vO'),
-
-            'addresses' => [
+            'addresses'             => [
                 [
                     'address1'    => $response->addresses[0]->address1,
                     'address2'    => $response->addresses[0]->address2,

--- a/tests/Unit/BusinessNumberValidatorTest.php
+++ b/tests/Unit/BusinessNumberValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyra\Tests\NzCompaniesOfficeLookup\Unit;
 
 use Hyra\NzCompaniesOfficeLookup\BusinessNumberValidator;
+use Hyra\NzCompaniesOfficeLookup\Stubs\BusinessNumberFaker;
 use PHPUnit\Framework\TestCase;
 
 class BusinessNumberValidatorTest extends TestCase
@@ -54,5 +55,25 @@ class BusinessNumberValidatorTest extends TestCase
             'invalid prefix'          => ['0231566199093'],
             'invalid GTIN-13'         => ['9429033128888'],
         ];
+    }
+
+    public function testRandomValidNumbers(): void
+    {
+        for ($i = 0; $i < 100; ++$i) {
+            $businessNumber = BusinessNumberFaker::validBusinessNumber();
+            $result         = BusinessNumberValidator::isValidNumber($businessNumber);
+
+            static::assertTrue($result, \sprintf('The number %s is not valid', $businessNumber));
+        }
+    }
+
+    public function testRandomInvalidNumbers(): void
+    {
+        for ($i = 0; $i < 100; ++$i) {
+            $businessNumber = BusinessNumberFaker::invalidBusinessNumber();
+            $result         = BusinessNumberValidator::isValidNumber($businessNumber);
+
+            static::assertFalse($result, \sprintf('The number %s is not invalid', $businessNumber));
+        }
     }
 }


### PR DESCRIPTION
The number validator was not checking the company prefix so any valid GTIN-13 number passed