### PR TITLE
chore(deps): Fix Symfony 6.3 normalizer deprecations

### DIFF
--- a/src/Model/AddressDenormalizer.php
+++ b/src/Model/AddressDenormalizer.php
@@ -44,8 +44,6 @@ final class AddressDenormalizer implements DenormalizerInterface, DenormalizerAw
 
     /**
      * @return array<'*'|'object'|class-string|string, null|bool>
-     *
-     * @psalm-suppress UnusedParam
      */
     public function getSupportedTypes(?string $format): array
     {

--- a/src/Model/AddressDenormalizer.php
+++ b/src/Model/AddressDenormalizer.php
@@ -41,4 +41,16 @@ final class AddressDenormalizer implements DenormalizerInterface, DenormalizerAw
 
         return $this->denormalizer->denormalize($data['addressList'], $type);
     }
+
+    /**
+     * @return array<'*'|'object'|class-string|string, null|bool>
+     *
+     * @psalm-suppress UnusedParam
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            'Hyra\NzCompaniesOfficeLookup\Model\AddressResponse[]' => false,
+        ];
+    }
 }


### PR DESCRIPTION
Symfony 6.3 adds a new method to normalizers/denormalizers: getSupportTypes.
symfony.com/blog/new-in-symfony-6-3-performance-improvements

Currently, for everything that it tries to normalize/denormalize, it will call every single normalizer/denormalizer.
The getSupportedTypes method allows it to know exactly what type the class supports, so that it doesn't call the AddressNormalizer when it's trying to normalize a DateTime.

You can make it cache even further by passing true back instead of false, but that means it will never call the supports* method again, and our supports* methods generally do more checks on the data.