### PR TITLE
Allow industry classification description to be nullable

### DIFF
--- a/src/Model/IndustryClassificationsResponse.php
+++ b/src/Model/IndustryClassificationsResponse.php
@@ -12,5 +12,5 @@ final class IndustryClassificationsResponse extends AbstractResponse
     public string $code;
 
     #[SerializedName('classificationDescription')]
-    public string $description;
+    public ?string $description;
 }

--- a/tests/Model/IndustryClassificationResponseTest.php
+++ b/tests/Model/IndustryClassificationResponseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyra\Tests\NzCompaniesOfficeLookup\Model;
+
+use Hyra\NzCompaniesOfficeLookup\Model\IndustryClassificationsResponse;
+
+final class IndustryClassificationResponseTest extends BaseModelTest
+{
+    public function testValidModel(): void
+    {
+        $data = <<<JSON
+          {
+            "classificationCode": "C121220",
+            "classificationDescription": "Breweries",
+            "uniqueIdentifier": "140987"
+          }
+        JSON;
+
+        /** @var IndustryClassificationsResponse $parsed */
+        $parsed = $this->valid($data, IndustryClassificationsResponse::class);
+
+        static::assertSame('C121220', $parsed->code);
+        static::assertSame('Breweries', $parsed->description);
+    }
+
+    public function testValidModelWithoutDescription(): void
+    {
+        $data = <<<JSON
+          {
+            "classificationCode": "C121220",
+            "classificationDescription": null,
+            "uniqueIdentifier": "140987"
+          }
+        JSON;
+
+        /** @var IndustryClassificationsResponse $parsed */
+        $parsed = $this->valid($data, IndustryClassificationsResponse::class);
+
+        static::assertSame('C121220', $parsed->code);
+        static::assertNull($parsed->description);
+    }
+
+    public function testInvalidModel(): void
+    {
+        $data = <<<JSON
+          {
+            "classificationCode": null,
+            "classificationDescription": "Breweries",
+            "uniqueIdentifier": "140987"
+          }
+        JSON;
+
+        $this->invalid($data, IndustryClassificationsResponse::class);
+    }
+}


### PR DESCRIPTION
Apparently it is possible that industry classifications return a code but lack a description (e.g. `E302010`). This PR makes the description nullable so it won't throw a serialisation error anymore.