### PR TITLE
fix(error): Update incorrect API name

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -50,7 +50,7 @@ final class ApiClient implements ApiClientInterface
             }
 
             throw new ConnectionException(
-                \sprintf('Unable to connect to the Companies House API: %s', $e->getMessage()),
+                \sprintf('Unable to connect to the Companies Office API: %s', $e->getMessage()),
                 $e
             );
         }


### PR DESCRIPTION
The error message that shows up in the logs when a connection with the API couldn’t be made incorrectly said `Companies House API` which is confusing as in NZ it is called the `Companies Office`.